### PR TITLE
Fix/storage tables missing identity

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -62,7 +62,6 @@ func azapiResource() config.ExternalName {
 	// Override GetExternalNameFn to handle resources where Azure API doesn't return
 	// the standard 'id' field (e.g., Storage Tables). Falls back to constructing
 	// the ID from parent_id and name when id is missing.
-	// See: https://github.com/upbound/provider-upjet-azapi/issues/XXX
 	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
 		// First try standard id field
 		if id, ok := tfstate["id"].(string); ok && id != "" {

--- a/config/external_name.go
+++ b/config/external_name.go
@@ -59,6 +59,26 @@ func azapiResource() config.ExternalName {
 		}
 		return xpprovider.NewResourceID(name, parentId, resourceType)
 	}
+	// Override GetExternalNameFn to handle resources where Azure API doesn't return
+	// the standard 'id' field (e.g., Storage Tables). Falls back to constructing
+	// the ID from parent_id and name when id is missing.
+	// See: https://github.com/upbound/provider-upjet-azapi/issues/XXX
+	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
+		// First try standard id field
+		if id, ok := tfstate["id"].(string); ok && id != "" {
+			return id, nil
+		}
+		// Fallback: construct from parent_id + name
+		// This handles Azure resources where the API response doesn't include
+		// the full ARM resource ID (e.g., Storage Tables, some nested resources)
+		parentId, hasParentId := tfstate["parent_id"].(string)
+		name, hasName := tfstate["name"].(string)
+		if hasParentId && hasName && parentId != "" && name != "" {
+			// Construct the resource ID in the format: {parent_id}/{name}
+			return parentId + "/" + name, nil
+		}
+		return "", errors.New("cannot determine resource identity: 'id' field is empty and fallback from 'parent_id'/'name' failed")
+	}
 	return e
 }
 

--- a/go.mod
+++ b/go.mod
@@ -152,4 +152,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/Azure/terraform-provider-azapi => github.com/upbound/terraform-provider-azapi v0.0.0-20251216073536-fa7bb6f0cc62 // v2.8.0-upjet.1
+replace github.com/Azure/terraform-provider-azapi => github.com/upbound/terraform-provider-azapi v0.0.0-20251017090720-3dd7f4b26f05

--- a/go.mod
+++ b/go.mod
@@ -152,4 +152,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/Azure/terraform-provider-azapi => github.com/upbound/terraform-provider-azapi v0.0.0-20251017090720-3dd7f4b26f05
+replace github.com/Azure/terraform-provider-azapi => github.com/upbound/terraform-provider-azapi v0.0.0-20251017090720-3dd7f4b26f05 // v2.7.0-upjet.1

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
-github.com/upbound/terraform-provider-azapi v0.0.0-20251216073536-fa7bb6f0cc62 h1:OhiWU1kE6uF+ZKYGM3VK6XCj6nXkmFg0SAGi157HqiU=
-github.com/upbound/terraform-provider-azapi v0.0.0-20251216073536-fa7bb6f0cc62/go.mod h1:9zaKxXlGimvg3BKj+Iyms2/C40+ObatohcJg2U1LMfk=
+github.com/upbound/terraform-provider-azapi v0.0.0-20251017090720-3dd7f4b26f05 h1:zzFfRW98MDmcXu/4dvs3kbwUui+z6PB3+m1XZ+HwCvw=
+github.com/upbound/terraform-provider-azapi v0.0.0-20251017090720-3dd7f4b26f05/go.mod h1:LWOxEB+pAzifaF73CYBVuOPV9S49DLqQCDa7bmY02O8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
# fix: downgrade terraform-provider-azapi to v2.7.0 to fix ResourceWithIdentity incompatibility

## Problem

The terraform-provider-azapi v2.8.0 introduced support for Terraform 1.12's `ResourceWithIdentity` interface. However, upjet does not implement this interface, causing **'Missing Resource Identity After Read'** errors when managing resources like Azure Storage Tables.

### Error
```
cannot run refresh: refresh failed: Missing Resource Identity After Read: 
The provider returned a resource with no identity set in the ReadResource response. 
Resources of type "azapi_resource" should always include an identity value in the 
ReadResource response to support identity-based imports.
```

### Root Cause
- terraform-provider-azapi v2.8.0 implements `ResourceWithIdentity` interface (Terraform Plugin Framework)
- upjet v2.2.1 does not support `ResourceWithIdentity` - it has stub implementations that panic
- When Terraform Plugin Framework validates the resource, it requires identity to be non-null after Read for resources implementing this interface

## Solution

Downgrade to terraform-provider-azapi v2.7.0-upjet.1 which does not implement `ResourceWithIdentity`, allowing the provider to work correctly with upjet.

## Testing

Verified that Azure Storage Tables now create/update/delete correctly with full management policies.

## Related

- Terraform Plugin Framework validation: `server_readresource.go:203-210`
- terraform-provider-azapi v2.8.0 release notes mention: "Add support for identity-based import"
