### PR TITLE
ci: unify and use Go version from go.mod in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   detect-noop:
     runs-on: ubuntu-latest
@@ -71,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Analysis Cache
         id: analysis_cache
@@ -119,7 +116,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
@@ -169,7 +166,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -199,7 +196,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -8,9 +8,6 @@ on:
   issue_comment:
     types: [created]
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   debug:
     runs-on: ubuntu-latest
@@ -18,7 +15,6 @@ jobs:
       - name: Debug
         run: |
           echo "Trigger keyword: '/test-examples'"
-          echo "Go version: ${{ env.GO_VERSION }}"
           echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
 
   get-example-list:
@@ -102,11 +98,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Checkout PR
         id: checkout-pr
         env:
@@ -116,6 +107,11 @@ jobs:
           git submodule update --init --recursive
           OUTPUT=$(git log -1 --format='%H')
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GO_REQUIRED_VERSION ?= 1.24
+GO_REQUIRED_VERSION ?= $(shell grep -E '^go ' go.mod | awk '{print $2}')
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
 GOLANGCILINT_VERSION ?= 2.8.0


### PR DESCRIPTION
### Description of your changes

original work: https://github.com/crossplane-contrib/provider-upjet-aws/pull/2000

This PR eliminates hardcoded Go version values across the repository by making `go.mod` the single source of truth for the Go version.

- **Workflows**: Updated `ci.yml` and `uptest-trigger.yaml` to use `go-version-file: go.mod` instead of the hardcoded `GO_VERSION` environment variable
- **Makefile**: Changed `GO_REQUIRED_VERSION` to dynamically read from `go.mod` using shell parsing
- **uptest-trigger.yaml**: Moved Setup Go step to after Checkout PR step to ensure `go.mod` is available before reading it

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

CI

[contribution process]: https://git.io/fj2m9
