### PR TITLE
Bump storage&controller version for CRDs that served multi-version, and start deprecation process for the old versions

### DIFF
--- a/apis/cluster/resources/v1beta1/zz_dataplaneresource_types.go
+++ b/apis/cluster/resources/v1beta1/zz_dataplaneresource_types.go
@@ -364,9 +364,10 @@ type DataPlaneResourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This API version is deprecated. Deprecated since v2.1.0."
 
 // DataPlaneResource is the Schema for the DataPlaneResources API. Manages a Azure data plane resource
+// Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/apis/cluster/resources/v1beta1/zz_resource_types.go
+++ b/apis/cluster/resources/v1beta1/zz_resource_types.go
@@ -492,9 +492,10 @@ type ResourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This API version is deprecated. Deprecated since v2.1.0."
 
 // Resource is the Schema for the Resources API. Manages a Azure resource
+// Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/apis/cluster/resources/v1beta1/zz_resourceaction_types.go
+++ b/apis/cluster/resources/v1beta1/zz_resourceaction_types.go
@@ -363,9 +363,10 @@ type ResourceActionStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This API version is deprecated. Deprecated since v2.1.0."
 
 // ResourceAction is the Schema for the ResourceActions API. Perform resource action which changes an existing resource's state
+// Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/apis/cluster/resources/v1beta1/zz_updateresource_types.go
+++ b/apis/cluster/resources/v1beta1/zz_updateresource_types.go
@@ -347,9 +347,10 @@ type UpdateResourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This API version is deprecated. Deprecated since v2.1.0."
 
 // UpdateResource is the Schema for the UpdateResources API. Manages a subset of an existing azure resource's properties
+// Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/apis/cluster/resources/v1beta2/zz_dataplaneresource_types.go
+++ b/apis/cluster/resources/v1beta2/zz_dataplaneresource_types.go
@@ -401,6 +401,7 @@ type DataPlaneResourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // DataPlaneResource is the Schema for the DataPlaneResources API. This resource can manage some Azure data plane resources.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/apis/cluster/resources/v1beta2/zz_resource_types.go
+++ b/apis/cluster/resources/v1beta2/zz_resource_types.go
@@ -542,6 +542,7 @@ type ResourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // Resource is the Schema for the Resources API. This resource can manage any Azure Resource Manager resource.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/apis/cluster/resources/v1beta2/zz_resourceaction_types.go
+++ b/apis/cluster/resources/v1beta2/zz_resourceaction_types.go
@@ -410,6 +410,7 @@ type ResourceActionStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // ResourceAction is the Schema for the ResourceActions API. This resource allows you to perform an action on an existing Azure resource.g., starting or stopping an Azure Virtual Machine.	Please note that when deleting this resource, no action will be performed on the Azure resource unless the when argument is set to destroy.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/apis/cluster/resources/v1beta2/zz_updateresource_types.go
+++ b/apis/cluster/resources/v1beta2/zz_updateresource_types.go
@@ -418,6 +418,7 @@ type UpdateResourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // UpdateResource is the Schema for the UpdateResources API. This resource can manage a subset of any existing Azure resource manager resource's properties. -> Note This resource is used to add or modify properties on an existing resource. When azapi_update_resource is deleted, no operation will be performed, and these properties will stay unchanged. If you want to restore the modified properties to some values, you must apply the restored properties before deleting.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/config/cluster/resources/config.go
+++ b/config/cluster/resources/config.go
@@ -30,7 +30,7 @@ func Configure(p *config.Provider) {
 		r.Version = versionV1Beta2
 		r.PreviousVersions = []string{versionV1Beta1}
 		r.ControllerReconcileVersion = versionV1Beta2 //nolint:staticcheck // still handling the deprecated behavior until rollout
-		r.SetCRDStorageVersion(versionV1Beta1)
+		r.SetCRDStorageVersion(r.Version)
 		r.Conversions = r.Conversions[1:]
 		typeChangingPaths := []string{"body", "output", "responseExportValues"}
 		r.Conversions = append(r.Conversions,
@@ -38,6 +38,14 @@ func Configure(p *config.Provider) {
 			conversion.NewCustomConverter(versionV1Beta1, versionV1Beta2, dataPlaneResourceConverterFromv1beta1Tov1beta2),
 			conversion.NewCustomConverter(versionV1Beta2, versionV1Beta1, dataPlaneResourceConverterFromv1beta2Tov1beta1),
 		)
+		if err := r.SetDeprecatedVersion("v1beta1",
+			config.VersionDeprecation{
+				Warning:            "This API version is deprecated.",
+				DeprecationRelease: "v2.1.0",
+			}); err != nil {
+			panic(err)
+		}
+
 		// Following attributes trigger TF resource replacement, which is not
 		// supported per XRM in Crossplane.
 		delete(r.TerraformResource.Schema, "replace_triggers_external_values")
@@ -54,7 +62,7 @@ func Configure(p *config.Provider) {
 		r.Version = versionV1Beta2
 		r.PreviousVersions = []string{versionV1Beta1}
 		r.ControllerReconcileVersion = versionV1Beta2 //nolint:staticcheck // still handling the deprecated behavior until rollout
-		r.SetCRDStorageVersion(versionV1Beta1)
+		r.SetCRDStorageVersion(r.Version)
 		r.Conversions = r.Conversions[1:]
 		typeChangingPaths := []string{"body", "output", "responseExportValues"}
 		r.Conversions = append(r.Conversions,
@@ -62,6 +70,13 @@ func Configure(p *config.Provider) {
 			conversion.NewCustomConverter(versionV1Beta1, versionV1Beta2, azapiResourceConverterFromv1beta1Tov1beta2),
 			conversion.NewCustomConverter(versionV1Beta2, versionV1Beta1, azapiResourceConverterFromv1beta2Tov1beta1),
 		)
+		if err := r.SetDeprecatedVersion("v1beta1",
+			config.VersionDeprecation{
+				Warning:            "This API version is deprecated.",
+				DeprecationRelease: "v2.1.0",
+			}); err != nil {
+			panic(err)
+		}
 		// Following attributes trigger TF resource replacement, which is not
 		// supported per XRM in Crossplane.
 		delete(r.TerraformResource.Schema, "replace_triggers_external_values")
@@ -79,7 +94,7 @@ func Configure(p *config.Provider) {
 		r.Version = versionV1Beta2
 		r.PreviousVersions = []string{versionV1Beta1}
 		r.ControllerReconcileVersion = versionV1Beta2 //nolint:staticcheck // still handling the deprecated behavior until rollout
-		r.SetCRDStorageVersion(versionV1Beta1)
+		r.SetCRDStorageVersion(r.Version)
 		r.Conversions = r.Conversions[1:]
 		typeChangingPaths := []string{"body", "output", "responseExportValues"}
 		r.Conversions = append(r.Conversions,
@@ -87,6 +102,13 @@ func Configure(p *config.Provider) {
 			conversion.NewCustomConverter(versionV1Beta1, versionV1Beta2, resourceActionConverterFromv1beta1Tov1beta2),
 			conversion.NewCustomConverter(versionV1Beta2, versionV1Beta1, resourceActionConverterFromv1beta2Tov1beta1),
 		)
+		if err := r.SetDeprecatedVersion("v1beta1",
+			config.VersionDeprecation{
+				Warning:            "This API version is deprecated.",
+				DeprecationRelease: "v2.1.0",
+			}); err != nil {
+			panic(err)
+		}
 		// disable scraped argument docs to prevent duplicate field
 		// descriptions in CRD schema as all fields have descriptions
 		// provided by their TF schema
@@ -102,7 +124,7 @@ func Configure(p *config.Provider) {
 		r.Version = versionV1Beta2
 		r.PreviousVersions = []string{versionV1Beta1}
 		r.ControllerReconcileVersion = versionV1Beta2 //nolint:staticcheck // still handling the deprecated behavior until rollout
-		r.SetCRDStorageVersion(versionV1Beta1)
+		r.SetCRDStorageVersion(r.Version)
 		r.Conversions = r.Conversions[1:]
 		typeChangingPaths := []string{"body", "output", "responseExportValues"}
 		r.Conversions = append(r.Conversions,
@@ -110,6 +132,13 @@ func Configure(p *config.Provider) {
 			conversion.NewCustomConverter(versionV1Beta1, versionV1Beta2, updateResourceConverterFromv1beta1Tov1beta2),
 			conversion.NewCustomConverter(versionV1Beta2, versionV1Beta1, updateResourceConverterFromv1beta2Tov1beta1),
 		)
+		if err := r.SetDeprecatedVersion("v1beta1",
+			config.VersionDeprecation{
+				Warning:            "This API version is deprecated.",
+				DeprecationRelease: "v2.1.0",
+			}); err != nil {
+			panic(err)
+		}
 		// Following attributes trigger TF resource replacement, which is not
 		// supported per XRM in Crossplane.
 		delete(r.TerraformResource.Schema, "replace_triggers_external_values")

--- a/package/crds/resources.azapi.upbound.io_dataplaneresources.yaml
+++ b/package/crds/resources.azapi.upbound.io_dataplaneresources.yaml
@@ -31,11 +31,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
+    deprecationWarning: This API version is deprecated. Deprecated since v2.1.0.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: DataPlaneResource is the Schema for the DataPlaneResources API.
-          Manages a Azure data plane resource
+        description: |-
+          DataPlaneResource is the Schema for the DataPlaneResources API. Manages a Azure data plane resource
+          Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
         properties:
           apiVersion:
             description: |-
@@ -713,7 +716,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1452,6 +1455,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/package/crds/resources.azapi.upbound.io_resourceactions.yaml
+++ b/package/crds/resources.azapi.upbound.io_resourceactions.yaml
@@ -31,11 +31,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
+    deprecationWarning: This API version is deprecated. Deprecated since v2.1.0.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ResourceAction is the Schema for the ResourceActions API. Perform
-          resource action which changes an existing resource's state
+        description: |-
+          ResourceAction is the Schema for the ResourceActions API. Perform resource action which changes an existing resource's state
+          Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
         properties:
           apiVersion:
             description: |-
@@ -631,7 +634,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1299,6 +1302,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/package/crds/resources.azapi.upbound.io_resources.yaml
+++ b/package/crds/resources.azapi.upbound.io_resources.yaml
@@ -31,11 +31,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
+    deprecationWarning: This API version is deprecated. Deprecated since v2.1.0.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Resource is the Schema for the Resources API. Manages a Azure
-          resource
+        description: |-
+          Resource is the Schema for the Resources API. Manages a Azure resource
+          Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
         properties:
           apiVersion:
             description: |-
@@ -896,7 +899,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1835,6 +1838,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/package/crds/resources.azapi.upbound.io_updateresources.yaml
+++ b/package/crds/resources.azapi.upbound.io_updateresources.yaml
@@ -31,11 +31,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
+    deprecationWarning: This API version is deprecated. Deprecated since v2.1.0.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: UpdateResource is the Schema for the UpdateResources API. Manages
-          a subset of an existing azure resource's properties
+        description: |-
+          UpdateResource is the Schema for the UpdateResources API. Manages a subset of an existing azure resource's properties
+          Deprecated: This API version (v1beta1) has been deprecated in release v2.1.0.
         properties:
           apiVersion:
             description: |-
@@ -680,7 +683,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1435,6 +1438,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}


### PR DESCRIPTION
### Description of your changes

This PR bumps the storage & controller versions for CRDs that support multiple versions and starts the deprecation process for the old versions.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- examples/cluster/resources/v1beta2/dataplaneresource.yaml: https://github.com/upbound/provider-upjet-azapi/actions/runs/25680040380
- examples/cluster/resources/v1beta2/resourceaction.yaml: https://github.com/upbound/provider-upjet-azapi/actions/runs/25684133554
- examples/cluster/resources/v1beta2/updateresource.yaml: https://github.com/upbound/provider-upjet-azapi/actions/runs/25720347853
- examples/cluster/resources/v1beta1/dataplaneresource.yaml:  https://github.com/upbound/provider-upjet-azapi/actions/runs/25674307537
- examples/cluster/resources/v1beta1/resourceaction.yaml: https://github.com/upbound/provider-upjet-azapi/actions/runs/25678466557
- examples/cluster/resources/v1beta1/updateresource.yaml: https://github.com/upbound/provider-upjet-azapi/actions/runs/25679133356

[contribution process]: https://git.io/fj2m9
