### PR TITLE
fix: sensitive_body field type backport for DataplaneResource v1beta1

### DIFF
--- a/apis/cluster/resources/v1beta1/zz_dataplaneresource_types.go
+++ b/apis/cluster/resources/v1beta1/zz_dataplaneresource_types.go
@@ -69,6 +69,13 @@ type DataPlaneResourceInitParameters struct {
 	// (Attributes) The retry object supports the following attributes: (see below for nested schema)
 	Retry *RetryInitParameters `json:"retry,omitempty" tf:"retry,omitempty"`
 
+	// A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+	SensitiveBody *apiextv1.JSON `json:"sensitiveBody,omitempty" tf:"sensitive_body,omitempty"`
+
+	// A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
+	// +mapType=granular
+	SensitiveBodyVersion map[string]*string `json:"sensitiveBodyVersion,omitempty" tf:"sensitive_body_version,omitempty"`
+
 	// It is in a format like <resource-type>@<api-version>. <api-version> is version of the API used to manage this azure data plane resource.
 	Type *string `json:"type,omitempty" tf:"type,omitempty"`
 
@@ -238,10 +245,9 @@ type DataPlaneResourceParameters struct {
 	// +kubebuilder:validation:Optional
 	Retry *RetryParameters `json:"retry,omitempty" tf:"retry,omitempty"`
 
-	// A JSON-encoded string that contains the request body.
-	// A JSON-encoded string that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+	// A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
 	// +kubebuilder:validation:Optional
-	SensitiveBody *string `json:"sensitiveBody,omitempty" tf:"sensitive_body,omitempty"`
+	SensitiveBody *apiextv1.JSON `json:"sensitiveBody,omitempty" tf:"sensitive_body,omitempty"`
 
 	// A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 	// +kubebuilder:validation:Optional

--- a/apis/cluster/resources/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/resources/v1beta1/zz_generated.deepcopy.go
@@ -209,6 +209,27 @@ func (in *DataPlaneResourceInitParameters) DeepCopyInto(out *DataPlaneResourceIn
 		*out = new(RetryInitParameters)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SensitiveBody != nil {
+		in, out := &in.SensitiveBody, &out.SensitiveBody
+		*out = new(v1.JSON)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.SensitiveBodyVersion != nil {
+		in, out := &in.SensitiveBodyVersion, &out.SensitiveBodyVersion
+		*out = make(map[string]*string, len(*in))
+		for key, val := range *in {
+			var outVal *string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = new(string)
+				**out = **in
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
 		*out = new(string)
@@ -722,8 +743,8 @@ func (in *DataPlaneResourceParameters) DeepCopyInto(out *DataPlaneResourceParame
 	}
 	if in.SensitiveBody != nil {
 		in, out := &in.SensitiveBody, &out.SensitiveBody
-		*out = new(string)
-		**out = **in
+		*out = new(v1.JSON)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SensitiveBodyVersion != nil {
 		in, out := &in.SensitiveBodyVersion, &out.SensitiveBodyVersion

--- a/package/crds/resources.azapi.upbound.io_dataplaneresources.yaml
+++ b/package/crds/resources.azapi.upbound.io_dataplaneresources.yaml
@@ -196,10 +196,10 @@ spec:
                         type: number
                     type: object
                   sensitiveBody:
-                    description: |-
-                      A JSON-encoded string that contains the request body.
-                      A JSON-encoded string that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
-                    type: string
+                    description: A dynamic attribute that contains the write-only
+                      properties of the request body. This will be merge-patched to
+                      the body to construct the actual request body.
+                    x-kubernetes-preserve-unknown-fields: true
                   sensitiveBodyVersion:
                     additionalProperties:
                       type: string
@@ -364,6 +364,22 @@ spec:
                           The randomization factor to apply to the interval between retries. The formula for the randomized interval is: `RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])`. Therefore set to zero `0.0` for no randomization. Default is `0.5`.
                         type: number
                     type: object
+                  sensitiveBody:
+                    description: A dynamic attribute that contains the write-only
+                      properties of the request body. This will be merge-patched to
+                      the body to construct the actual request body.
+                    x-kubernetes-preserve-unknown-fields: true
+                  sensitiveBodyVersion:
+                    additionalProperties:
+                      type: string
+                    description: A map where the key is the path to the property in
+                      `sensitive_body` and the value is the version of the property.
+                      The key is a string in the format of `path.to.property[index].subproperty`,
+                      where `index` is the index of the item in an array. When the
+                      version is changed, the property will be included in the request
+                      body, otherwise it will be omitted from the request body.
+                    type: object
+                    x-kubernetes-map-type: granular
                   type:
                     description: It is in a format like <resource-type>@<api-version>.
                       <api-version> is version of the API used to manage this azure


### PR DESCRIPTION
### Description of your changes

This PR fixes field backport in cluster-scoped `DataplaneResource` `azapi.upbound.io/v1beta1` API
Changes are NOT breaking, as they only fix fields that are previously not working/specifiable.

- Fix missing backports in initProvider:
  - `spec.initProvider.sensitiveBody`
  - `spec.initProvider.sensitiveBodyVersion `
- Fix backported field with wrong type, failing the conversion.
  - `spec.forProvider.sensitiveBody`

> [!NOTE]
> cluster-scoped `v1beta2`+ and namespaced APIs (`DataplaneResource.azapi.m.upbound.io`) are not affected/changed.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

using the new roundtrip testing library at https://github.com/crossplane/upjet/pull/636

[contribution process]: https://git.io/fj2m9
