### PR TITLE
Add api roundtrip tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GO_REQUIRED_VERSION ?= $(shell grep -E '^go ' go.mod | awk '{print $2}')
 GOLANGCILINT_VERSION ?= 2.11.4
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
-GO_SUBDIRS += cmd internal apis
+GO_SUBDIRS += cmd internal apis config
 -include build/makelib/golang.mk
 
 # ====================================================================================

--- a/config/test/roundtrip/custom_fillers_test.go
+++ b/config/test/roundtrip/custom_fillers_test.go
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package roundtrip
+
+import (
+	"encoding/json"
+
+	"github.com/crossplane/upjet/v2/pkg/apitesting/roundtrip"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/randfill"
+
+	resourcesv1beta1 "github.com/upbound/provider-azapi/v2/apis/cluster/resources/v1beta1"
+	resourcesv1beta2 "github.com/upbound/provider-azapi/v2/apis/cluster/resources/v1beta2"
+)
+
+// validJSONObjects are pre-built valid JSON object payloads resembling AzAPI request bodies.
+// Keys at every nesting level must be in alphabetical order so that roundtripping through
+// Kubernetes unstructured conversion (which re-marshals via map[string]interface{} and
+// sorts keys) produces identical bytes on the way back.
+// Additional constraints:
+//   - Avoid numbers that lose precision as float64 (json.Unmarshal decodes all numbers to float64
+//     for interface{} targets, so very large integers change value).
+//   - Avoid trailing-zero floats like 1.0 — json.Marshal(float64(1)) emits "1", not "1.0".
+//   - Unicode escape sequences like A decode to the character "A" and re-encode as "A",
+//     so use literal characters rather than escape sequences.
+var validJSONObjects = []json.RawMessage{
+	// minimal / zero-value body
+	json.RawMessage(`{}`),
+	// single-key flat object
+	json.RawMessage(`{"location":"eastus"}`),
+	// nested object (sku is common in ARM)
+	json.RawMessage(`{"sku":{"capacity":1,"name":"Standard"}}`),
+	// flat object with two scalar types
+	json.RawMessage(`{"properties":{"enabled":true,"tier":"Standard"}}`),
+	// realistic storage-account body: multiple top-level keys, nested properties
+	// (alphabetical at every level: kind < location < properties < sku;
+	//  inside properties: accessTier < allowBlobPublicAccess < minimumTlsVersion < supportsHttpsTrafficOnly)
+	json.RawMessage(`{"kind":"StorageV2","location":"eastus","properties":{"accessTier":"Hot","allowBlobPublicAccess":false,"minimumTlsVersion":"TLS1_2","supportsHttpsTrafficOnly":true},"sku":{"name":"Standard_LRS"}}`),
+	// body with an array-valued property and string tags map
+	// (alphabetical: location < locks < tags; inside tags: environment < owner)
+	json.RawMessage(`{"location":"westus","locks":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet"],"tags":{"environment":"prod","owner":"platform"}}`),
+	// body with a null-valued property (null passes through unstructured as nil → "null")
+	// (alphabetical: location < properties; inside properties: extendedLocation < hardwareProfile < osProfile;
+	//  inside hardwareProfile: vmSize; inside osProfile: adminUsername < computerName)
+	json.RawMessage(`{"location":"eastus","properties":{"extendedLocation":null,"hardwareProfile":{"vmSize":"Standard_D2s_v3"},"osProfile":{"adminUsername":"azureuser","computerName":"vm01"}}}`),
+}
+
+// validJSONStringArrays are pre-built JSON arrays of strings.
+// responseExportValues in v1beta2 is *v1.JSON but roundtrips through []*string in v1beta1,
+// so the JSON must be a valid string array (not an arbitrary JSON object).
+// The arrays are compared after json.Marshal([]*string{...}), which produces compact JSON with
+// no extra whitespace, so entries here must not contain spaces either.
+var validJSONStringArrays = []json.RawMessage{
+	// empty — callers that treat nil and empty the same still pass
+	json.RawMessage(`[]`),
+	// wildcard — export the full response body
+	json.RawMessage(`["*"]`),
+	// single top-level property
+	json.RawMessage(`["properties.loginServer"]`),
+	// two nested paths (common for ACR output)
+	json.RawMessage(`["properties.loginServer","properties.policies.quarantinePolicy.status"]`),
+	// VM-style paths including bracket-indexed sub-resource
+	json.RawMessage(`["properties.networkProfile.networkInterfaces[0].id","properties.storageProfile.osDisk.name"]`),
+	// storage account paths — three sibling properties
+	json.RawMessage(`["properties.accessTier","properties.minimumTlsVersion","properties.supportsHttpsTrafficOnly"]`),
+}
+
+// validJSONStrings are valid JSON-encoded strings usable for v1beta1 *string body/output fields.
+// These go through the custom converter (string ↔ v1.JSON raw bytes), not identity conversion,
+// so key ordering does not need to be alphabetical.
+var validJSONStrings = []string{
+	`{}`,
+	`{"location":"eastus"}`,
+	`{"sku":{"name":"Standard","capacity":1}}`,
+	`{"properties":{"enabled":true}}`,
+	`{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa","properties":{"primaryEndpoints":{"blob":"https://sa.blob.core.windows.net/"},"provisioningState":"Succeeded"}}`,
+}
+
+func randJSONStringArray(c randfill.Continue) *apiextv1.JSON {
+	return &apiextv1.JSON{Raw: validJSONStringArrays[c.Intn(len(validJSONStringArrays))]}
+}
+
+func randJSONString(c randfill.Continue) *string {
+	s := validJSONStrings[c.Intn(len(validJSONStrings))]
+	return &s
+}
+
+// fuzzStringJSON replaces a non-nil *string with valid JSON (preserving nil).
+func fuzzStringJSON(sp **string, c randfill.Continue) {
+	if *sp != nil {
+		*sp = randJSONString(c)
+	}
+}
+
+// fuzzJSONStringArray replaces a non-nil *apiextv1.JSON with a JSON string array (preserving nil).
+// Used for responseExportValues which must survive json.Unmarshal into []*string in v1beta1.
+func fuzzJSONStringArray(jp **apiextv1.JSON, c randfill.Continue) {
+	if *jp != nil {
+		*jp = randJSONStringArray(c)
+	}
+}
+
+var azapiCustomFuzzers = []roundtrip.FuzzFunc{
+	// Type-level fuzzer: whenever randfill needs to fill an *apiextv1.JSON value,
+	// produce a valid JSON object instead of random bytes.
+	// This covers body, output, sensitiveBody and sensitiveResponseExportValues fields
+	// which are *v1.JSON in both v1beta1 and v1beta2.
+	apiExtJSONFuzzer,
+	fuzzDataplaneResourceV1Beta1,
+	fuzzResourceV1Beta1,
+	fuzzUpdateResourceV1Beta1,
+	fuzzResourceActionV1Beta1,
+	fuzzDataplaneResourceV1Beta2,
+	fuzzResourceV1Beta2,
+	fuzzUpdateResourceV1Beta2,
+	fuzzResourceActionV1Beta2,
+}
+
+// apiExtJSONFuzzer fills *apiextv1.JSON with a valid JSON object.
+func apiExtJSONFuzzer(j *apiextv1.JSON, c randfill.Continue) {
+	j.Raw = validJSONObjects[c.Intn(len(validJSONObjects))]
+}
+
+// --- v1beta1 fuzzers ---
+// In v1beta1: body and output are *string (need valid JSON to cleanly roundtrip
+// through *v1.JSON in v1beta2). sensitiveBody is *apiextv1.JSON and is handled
+// by apiExtJSONFuzzer. responseExportValues is []*string and roundtrips freely.
+
+func fuzzDataplaneResourceV1Beta1(s *resourcesv1beta1.DataPlaneResource, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzStringJSON(&s.Spec.ForProvider.Body, c)
+	fuzzStringJSON(&s.Spec.InitProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Output, c)
+}
+
+func fuzzResourceV1Beta1(s *resourcesv1beta1.Resource, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzStringJSON(&s.Spec.ForProvider.Body, c)
+	fuzzStringJSON(&s.Spec.InitProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Output, c)
+}
+
+func fuzzUpdateResourceV1Beta1(s *resourcesv1beta1.UpdateResource, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzStringJSON(&s.Spec.ForProvider.Body, c)
+	fuzzStringJSON(&s.Spec.InitProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Output, c)
+}
+
+func fuzzResourceActionV1Beta1(s *resourcesv1beta1.ResourceAction, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzStringJSON(&s.Spec.ForProvider.Body, c)
+	fuzzStringJSON(&s.Spec.InitProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Body, c)
+	fuzzStringJSON(&s.Status.AtProvider.Output, c)
+}
+
+// --- v1beta2 fuzzers ---
+// In v1beta2: body, output, sensitiveBody, and sensitiveResponseExportValues are *v1.JSON
+// and are handled by apiExtJSONFuzzer (any valid JSON works since they roundtrip as strings
+// in v1beta1). responseExportValues is *v1.JSON in v1beta2 but []*string in v1beta1, so the
+// JSON must be a valid string array.
+
+func fuzzDataplaneResourceV1Beta2(s *resourcesv1beta2.DataPlaneResource, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzJSONStringArray(&s.Spec.ForProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Spec.InitProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Status.AtProvider.ResponseExportValues, c)
+}
+
+func fuzzResourceV1Beta2(s *resourcesv1beta2.Resource, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzJSONStringArray(&s.Spec.ForProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Spec.InitProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Status.AtProvider.ResponseExportValues, c)
+}
+
+func fuzzUpdateResourceV1Beta2(s *resourcesv1beta2.UpdateResource, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzJSONStringArray(&s.Spec.ForProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Spec.InitProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Status.AtProvider.ResponseExportValues, c)
+}
+
+func fuzzResourceActionV1Beta2(s *resourcesv1beta2.ResourceAction, c randfill.Continue) {
+	c.FillNoCustom(s)
+	fuzzJSONStringArray(&s.Spec.ForProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Spec.InitProvider.ResponseExportValues, c)
+	fuzzJSONStringArray(&s.Status.AtProvider.ResponseExportValues, c)
+	// SensitiveResponseExportValues is *v1.JSON in both versions (identity conversion),
+	// handled by apiExtJSONFuzzer — no string-array override needed.
+}

--- a/config/test/roundtrip/roundtrip_test.go
+++ b/config/test/roundtrip/roundtrip_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// package roundtrip contains API roundtrip tests
+// for multi-version managed resource APIs
+package roundtrip
+
+import (
+	"testing"
+
+	"github.com/crossplane/upjet/v2/pkg/apitesting/roundtrip"
+	clusterapis "github.com/upbound/provider-azapi/v2/apis/cluster"
+	namespacedapis "github.com/upbound/provider-azapi/v2/apis/namespaced"
+	"github.com/upbound/provider-azapi/v2/config"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRoundTrip(t *testing.T) {
+	provider, err := config.GetProvider(t.Context(), false)
+	if err != nil {
+		t.Fatalf("GetProvider: %s", err)
+	}
+	providerNamespaced, err := config.GetProviderNamespaced(t.Context(), false)
+	if err != nil {
+		t.Fatalf("GetNamespacedProvider: %s", err)
+	}
+
+	testScheme := runtime.NewScheme()
+	if err := clusterapis.AddToScheme(testScheme); err != nil {
+		t.Fatalf("cluster-scoped apis AddToScheme: %s", err)
+	}
+	if err := namespacedapis.AddToScheme(testScheme); err != nil {
+		t.Fatalf("namespaced apis AddToScheme: %s", err)
+	}
+
+	rt, err := roundtrip.NewRoundTripTest(provider, providerNamespaced, testScheme,
+		roundtrip.WithFuzzerConfig(
+			roundtrip.FuzzerIterations(10),
+			roundtrip.FuzzerNilChance(0)),
+		roundtrip.WithFuzzerConfig(
+			roundtrip.FuzzerIterations(30),
+			roundtrip.FuzzerNilChance(0.3)),
+		roundtrip.WithComparisonOptions(
+			roundtrip.EquateEmptyAndSingleZeroSlice(),
+			roundtrip.EquateNilAndZeroValuePtr(),
+		),
+		roundtrip.WithExtraFuzzFuncs(azapiCustomFuzzers...),
+	)
+	if err != nil {
+		t.Fatalf("NewRoundTripTest: %s", err)
+	}
+
+	t.Run("TestSerializationRoundtrip", func(t *testing.T) {
+		rt.TestSerializationRoundtrip(t)
+	})
+
+	t.Run("TestConversionRoundtrip", func(t *testing.T) {
+		rt.TestConversionRoundtrip(t)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
-	github.com/crossplane/upjet/v2 v2.2.1-0.20260414070754-c6d5213346ac
+	github.com/crossplane/upjet/v2 v2.2.1-0.20260517113542-0beea8e928de
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/pkg/errors v0.9.1
@@ -21,6 +21,7 @@ require (
 	k8s.io/client-go v0.35.4
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/controller-tools v0.20.1
+	sigs.k8s.io/randfill v1.0.0
 )
 
 require (
@@ -157,7 +158,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.2.0 h1:jLoQm9D5buk9lBqwRtQ40ueaFo
 github.com/crossplane/crossplane-runtime/v2 v2.2.0/go.mod h1:8I+x4w5bG4x8aO8ifF/QC8GZoNCN6v21NHzgoYPNYAQ=
 github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339 h1:MPbMxSlY+82UsjrLUAGyXlh/iX1tL5WNj8W9SOaq/nk=
 github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.2.1-0.20260414070754-c6d5213346ac h1:UTpdbFgBAcTesLtQvqp65dUueUzbcoydd0Ru6VLYH6I=
-github.com/crossplane/upjet/v2 v2.2.1-0.20260414070754-c6d5213346ac/go.mod h1:5Lxrd+g6r81gWPib3D8mAxvsQ81aieMs7jkhXtHFgmM=
+github.com/crossplane/upjet/v2 v2.2.1-0.20260517113542-0beea8e928de h1:fff9tIdd+k02/cAAFRoqLz2RE1Lhm8UhYZvDqNa7u6k=
+github.com/crossplane/upjet/v2 v2.2.1-0.20260517113542-0beea8e928de/go.mod h1:I8NuvZHSbskEUK2Ov/q9+MSHuS7rGkwiGUsaua3xleg=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=


### PR DESCRIPTION
### Description of your changes

Adds API (conversion & serialization) roundtrip tests for multiversion MR APIs.
Integrates API roundtrip testing library at https://github.com/crossplane/upjet/pull/636, see the PR description for details on how it works.

The aim is to verify after conversions or serializations, the original resource is intact with no missing data 

First, prepares a `RoundtripTest` instance by supplying a test scheme with all APIs registered and configuring fuzzers
#### Serialization roundtrip:
For each API in the scheme, create a runtime instance by fuzzing API values, according to the given fuzzer
Then serialize and deserialize, compare the original vs roundtripped are equal

#### Conversion roundtrip:
- test library discovers all APIs that has multiple versions
- for each multi-version API, classifies hub and spoke versions
- Then, for each hub-spoke  pair, runs the following
  - start with hub, convert to spoke, convert back to hub, compare original vs roundtripped hub
  - start with spoke, convert to hub, convert back to spoke, compare original vs roundtripped spoke

#### Example:
`FooResource` API has 3 versions: `v1beta1`, `v1beta2`, `v1beta3` and `v1beta1` is the hub version, others being spoke. Following tests will run:

for v1beta1 - v1beta2 pair:
- `Hub v1beta1 -> Spoke v1beta2 -> Hub v1beta1`
- `Spoke v1beta2 -> Hub v1beta1 -> Spoke v1beta2`

for v1beta1-v1beta3 pair
- `Hub v1beta1 -> Spoke v1beta3 -> Hub v1beta1`
- `Spoke v1beta3 -> Hub v1beta1 -> Spoke v1beta2`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make test` & CI

[contribution process]: https://git.io/fj2m9
